### PR TITLE
added support for multiple devices

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,10 @@ UVCControl.prototype.init = function() {
   var devices = usb.getDeviceList();
   for (var i=0;i<devices.length;i++) {
     if(this.options['deviceAddress'] === devices[i].deviceAddress) {
-      this.device = devices[i];
+      var descr = devices[i].deviceDescriptor;
+      if((this.vid === descr.idVendor) && (this.pid === descr.idProduct)) {
+        this.device = devices[i];
+      }
     }
   }
   if (!this.device) {

--- a/index.js
+++ b/index.js
@@ -117,7 +117,15 @@ module.exports = UVCControl;
 UVCControl.controls = Object.keys( Controls );
 
 UVCControl.prototype.init = function() {
-  this.device = usb.findByIds( this.vid, this.pid );
+  var devices = usb.getDeviceList();
+  for (var i=0;i<devices.length;i++) {
+    if(this.options['deviceAddress'] === devices[i].deviceAddress) {
+      this.device = devices[i];
+    }
+  }
+  if (!this.device) {
+    this.device = usb.findByIds( this.vid, this.pid );
+  }
   if (this.device) {
     this.device.open();
     this.interfaceNumber = detectVideoControlInterface( this.device );


### PR DESCRIPTION
using options deviceAddress. useful for when connecting multiple
webcams of the same type - e.g. two c920

```
var UVCControl= require('uvc-control');
var camera1= new UVCControl(0x046d, 0x082d, {deviceAddress: 0x9});
camera1.set('saturation', 0);
var camera2= new UVCControl(0x046d, 0x082d, {deviceAddress: 0xa});
camera2.set('saturation', 0);
```

look up the deviceAddress using
```
var usb = require('usb');
console.log(usb.getDeviceList());
```
or with IORegistryExplorer.app or similar.