### PR TITLE
Add link to uvcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Control a USB Video Class compliant webcam from node. Most modern USB webcams use a common set of controls standardized by the USB Implementers Forum. You can use this set of controls to change certain things on the camera, such as the brightness, contrast, zoom level, focus and so on.
 
+See also [`uvcc`](https://github.com/joelpurra/uvcc), which wraps uvc-control in a command line tool.
+
 ## Example
 
 ```javascript


### PR DESCRIPTION
- As `uvc-control` is a library for programmers, it's not trivial to use for non-programmers.
- `uvcc` is a newly developed command line tool for power-users who want to control their UVC cameras.
- `uvcc` is basically a command line wrapper around `uvc-control`.
- This commit adds a link to `uvcc` in `README.md`.

See

- https://joelpurra.com/projects/uvcc/
- https://www.npmjs.com/package/uvcc
- https://github.com/joelpurra/uvcc