### PR TITLE
V2 control transfer target device

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ class UVCControl extends EventEmitter {
 
     const controlType = {
       PU: 'processingUnit',
-      CT: 'inputTerminal',
+      CT: 'cameraInputTerminal',
       // VS: 'videoStream',
     } [control.type]
     const unit = this.ids[controlType]

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,5 @@
+const usb = require("usb")
+
 const KEY = {
   scanning_mode: 'scanning_mode',
   auto_exposure_mode: 'auto_exposure_mode',
@@ -49,8 +51,8 @@ const FIELD_TYPE = {
 }
 
 const BM_REQUEST_TYPE = {
-  GET: 0b10100001,
-  SET: 0b00100001,
+  GET: usb.LIBUSB_REQUEST_TYPE_CLASS | usb.LIBUSB_RECIPIENT_DEVICE | usb.LIBUSB_ENDPOINT_IN,
+  SET: usb.LIBUSB_REQUEST_TYPE_CLASS | usb.LIBUSB_RECIPIENT_DEVICE | usb.LIBUSB_ENDPOINT_OUT,
 }
 
 const CS = {

--- a/lib/controls.js
+++ b/lib/controls.js
@@ -43,8 +43,7 @@ const CONTROLS = {
   [KEY.auto_exposure_mode]: {
     description: `The Auto-Exposure Mode Control determines whether the device will provide automatic adjustment of the Exposure Time and Iris controls. Attempts to programmatically set the autoadjusted controls are then ignored. A GET_RES request issued to this control will return a bitmap of the modes supported by this control. A valid request to this control would have only one bit set (a single mode selected). This control must accept the GET_DEF request and return its default value.`,
     selector: CT.AE_MODE_CONTROL,
-    type: 'PU',
-    // type: 'CT', ??
+    type: 'CT',
     wLength: 1,
     requests: [
       REQUEST.SET_CUR,
@@ -70,8 +69,7 @@ const CONTROLS = {
   [KEY.auto_exposure_priority]: {
     description: 'The Auto-Exposure Priority Control is used to specify constraints on the Exposure Time Control when the Auto-Exposure Mode Control is set to Auto Mode or Shutter Priority Mode. A value of zero indicates that the frame rate must remain constant. A value of 1 indicates that the frame rate may be dynamically varied by the device. The default value is zero (0).',
     selector: CT.AE_PRIORITY_CONTROL,
-    // type: 'CT',
-    type: 'PU',
+    type: 'CT',
     wLength: 1,
     requests: [
       REQUEST.SET_CUR,
@@ -89,8 +87,7 @@ const CONTROLS = {
   [KEY.absolute_exposure_time]: {
     description: 'The Exposure Time (Absolute) Control is used to specify the length of exposure. This value is expressed in 100µs units, where 1 is 1/10,000th of a second, 10,000 is 1 second, and 100,000 is 10 seconds. A value of zero (0) is undefined. Note that the manual exposure control is further limited by the frame interval, which always has higher precedence. If the frame interval is changed to a value below the current value of the Exposure Control, the Exposure Control value will automatically be changed. The default Exposure Control value will be the current frame interval until an explicit exposure value is chosen. This control will not accept SET requests when the Auto-Exposure Mode control is in Auto mode or Aperture Priority mode, and the control pipe shall indicate a stall in this case. This control must accept the GET_DEF request and return its default value.',
     selector: CT.EXPOSURE_TIME_ABSOLUTE_CONTROL,
-    // type: 'CT',
-    type: 'PU',
+    type: 'CT',
     wLength: 4,
     requests: [
       REQUEST.GET_CUR,

--- a/test/vid-pid-deviceaddress.js
+++ b/test/vid-pid-deviceaddress.js
@@ -25,6 +25,8 @@ if (cam.device.deviceAddress !== deviceAddress) console.error(`Input device addr
 
 console.log(cam)
 
-UVCControl.controls.map(name => {
-  cam.get(name).then(val => console.log(name, val))
+Object.keys(UVCControl.controls).map(name => {
+  cam.get(name).then(val => {
+    console.log(name, val)
+  }).catch(error => console.error(name, error))
 })

--- a/test/vid-pid.js
+++ b/test/vid-pid.js
@@ -21,9 +21,8 @@ if (cam.device.deviceDescriptor.idProduct !== pid) console.error(`Input product 
 
 console.log(cam)
 
-UVCControl.controls.map(name => {
-  cam.get(name, (err, val) => {
-    if (err) throw err
+Object.keys(UVCControl.controls).map(name => {
+  cam.get(name).then(val => {
     console.log(name, val)
-  })
+  }).catch(error => console.error(name, error))
 })

--- a/test/vid.js
+++ b/test/vid.js
@@ -18,9 +18,8 @@ if (cam.device.deviceDescriptor.idVendor !== vid) console.error(`Input vendor ID
 
 console.log(cam)
 
-UVCControl.controls.map(name => {
-  cam.get(name, (err, val) => {
-    if (err) throw err
+Object.keys(UVCControl.controls).map(name => {
+  cam.get(name).then(val => {
     console.log(name, val)
-  })
+  }).catch(error => console.error(name, error))
 })


### PR DESCRIPTION
Work-in-progress patches to the future `node-uvc-control` v2, on `master`. Fixes Linux issues (primarily) but also compatibility with other cameras (confirmed by some `uvcc` users). Sorry for mixing issues in one pull request -- submitting this as a draft pull request for testing, and I'd be happy to split to multiple when it's confirmed to work.

- Fixes #58.
- Fixes #60.
- Fixes #62.

Fixes were created to get `uvcc` working, so testing (unfortunately still manually) is mostly done using the `uvcc` CLI.

- https://github.com/joelpurra/uvcc/issues/4

While `uvcc` v2 is not up to par with `node-uvc-control` v2, I've also fixed a few more basic `uvcc` features to get basic `uvcc export | uvcc import` functionality working. The `feature/uvc-control-v2-next` branch of `uvcc` targets the code in this pull request.

- https://github.com/joelpurra/node-uvc-control/tree/v2-control-transfer-target-device
- https://github.com/joelpurra/uvcc/tree/feature/uvc-control-v2-next

```shell
git clone "git@github.com:joelpurra/uvcc.git"
cd uvcc

git checkout feature/uvc-control-v2-next
git pull
rm -r node_modules/
npm install

./index.js --verbose ranges
./index.js --verbose export

# NOTE: not all settings can be set if they're in auto-mode -- fix pending.
./index.js --verbose export | ./index.js --verbose import
```

There are still bugs, both in `uvcc` (missing functionality, setting values when they're in auto-mode, etcetera) and `node-uvc-control` (spotted some on the byte-reading level). Tested on macOS and Ubuntu using a Logitech C920 (0x46d/0x82d) with node v12.

What are the results for your camera(s)? Any major issues? Please show some output for verification, along with the camera vendor/product ids.

---

Note: similar/backported fixes for Linux are available for `node-uvc-control` v1.0.2 in a separate branch, but github doesn't let me create pull request against tags.

- https://github.com/makenai/node-uvc-control/issues/58#issuecomment-540815829
